### PR TITLE
Added KeyBindings for Buttons by (Doesn't cover menus & menu items)

### DIFF
--- a/Odot/Odot/Views/ButtonIconText.xaml
+++ b/Odot/Odot/Views/ButtonIconText.xaml
@@ -16,6 +16,7 @@
         <TextBlock Text="{Binding ElementName=button, Path=Text}" 
                    FontWeight="Bold"
                    HorizontalAlignment="Center"/>
+        <AccessText Text="{Binding ElementName=button, Path=AltText}"/>
     </StackPanel>
     
 </Button>

--- a/Odot/Odot/Views/ButtonIconText.xaml.cs
+++ b/Odot/Odot/Views/ButtonIconText.xaml.cs
@@ -35,5 +35,16 @@ namespace Odot.Views
         public static readonly DependencyProperty TextProperty =
             DependencyProperty.Register("Text", typeof(string), typeof(ButtonIconText), new PropertyMetadata(string.Empty));
 
+
+        public string AltText
+        {
+            get { return (string)GetValue(AltTextProperty); }
+            set { SetValue(AltTextProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for AltText.  
+        public static readonly DependencyProperty AltTextProperty =
+            DependencyProperty.Register("AltText", typeof(string), typeof(ButtonIconText), new PropertyMetadata(string.Empty));
+
     }
 }

--- a/Odot/Odot/Views/MainToolBar.xaml
+++ b/Odot/Odot/Views/MainToolBar.xaml
@@ -24,21 +24,25 @@
                 <local:ButtonIconText ToolTip="New File.."
                                       IconPath="{StaticResource FileNewIconPath}"
                                       Text="New"
+                                      AltText="_New"
                                       Click="Button_Click_New"/>
 
                 <local:ButtonIconText ToolTip="Open File.."
                                       IconPath="{StaticResource FileOpenIconPath}"
                                       Text="Open"
+                                      AltText="_Open"
                                       Click="Button_Click_Open"/>
 
                 <local:ButtonIconText ToolTip="Save File.."
                                       IconPath="{StaticResource FileSaveIconPath}"
                                       Text="Save"
+                                      AltText="_Save"
                                       Click="Button_Click_Save"/>
 
                 <local:ButtonIconText ToolTip="Save File As.."
                                       IconPath="{StaticResource FileSaveAsIconPath}"
                                       Text="Save As"
+                                      AltText="Save _As"
                                       Click="Button_Click_SaveAs"/>
 
 
@@ -71,11 +75,13 @@
                 <local:ButtonIconText ToolTip="Settings.."
                                       IconPath="{StaticResource SettingsIconPath}"
                                       Text="Settings"
+                                      AltText="Settin_gs"
                                       Click="Button_Click_Settings"/>
 
                 <local:ButtonIconText ToolTip="About.."
                                       IconPath="{StaticResource AboutIconPath}"
                                       Text="About"
+                                      AltText="A_bout"
                                       Click="Button_Click_About"/>
                 
             </ToolBar>


### PR DESCRIPTION
1. Added AltText property and DependencyProperty as backing store.
2. Added AccessText to the ButtonIcon content with Binding to AltText.
3. Added AltText properties to New, Open, Save, Save As, Settings and About buttons.

Partial Fix for https://github.com/elgaspar/Odot/issues/1